### PR TITLE
Add error interceptor

### DIFF
--- a/test_server/staking/engine-backend.ts
+++ b/test_server/staking/engine-backend.ts
@@ -16,6 +16,17 @@ export class EngineBackend implements StakeEngine {
             timeout: 30000
             // todo: auth
         });
+        this.client.interceptors.response.use(
+            (response) => response,
+            (error) => {
+                if (error.response.data.message !== undefined) {
+                    return Promise.reject(
+                        `http error: ${error}\n\t${error.response.data.message}`
+                    );
+                }
+                return Promise.reject(error);
+            }
+        );
     }
 
     async registerCommunity(


### PR DESCRIPTION
Use interceptor to spit out the backend error instead of a generic promise rejected error for 400/500 status codes