### PR TITLE
Confirm transactions

### DIFF
--- a/test_server/index.ts
+++ b/test_server/index.ts
@@ -10,7 +10,7 @@ const port = 8081;
 const engine =
     process.env.ENGINE?.toLowerCase() === 'direct'
         ? new EngineDirect()
-        : new EngineBackend('http://localhost:8080/staking/v1/');
+        : new EngineBackend('http://localhost:8080/');
 console.log(
     `Engine: ${process.env.ENGINE === 'direct' ? 'direct' : 'backend'}`
 );


### PR DESCRIPTION
Counterpart to the backend transaction confirmation change.

* Changes test_server to confirm transactions after they've been submitted
* extract zee from confirmation
