### PR TITLE
[js] Use prepare instead of deprecated prepublish

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@zoints/staking",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "The JavaScript library for staking",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "build": "tsc -p .",
     "lint": "eslint src",
     "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' --write",


### PR DESCRIPTION
* Use npm script prepare instead of prepublish, which has been deprecated
* Bump version to 0.8.1