### PR TITLE
Fix account documentation

### DIFF
--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -88,9 +88,8 @@ pub enum StakingInstruction {
     ///     5. `[writable]` Staker's ZEE Token Account
     ///     6. `[]` Endpoint
     ///     7. `[]` Settings
-    ///     8. `[]` Pool Authority
-    ///     9. `[]` Clock Sysvar
-    ///     10. `[]` SPL Token Program
+    ///     8. `[]` Clock Sysvar
+    ///     9. `[]` SPL Token Program
     WithdrawUnbond,
     /// Claim Beneficiary Yield
     ///


### PR DESCRIPTION
Updates instruction.rs to fix the list of accounts for the `WithdrawUnbond` instruction. Removes the `PoolAuthority` from the list.