### PR TITLE
[js] More error decoding checks

### DIFF
--- a/test_server/staking/engine-backend.ts
+++ b/test_server/staking/engine-backend.ts
@@ -98,15 +98,10 @@ export class EngineBackend implements StakeEngine {
         const data = Buffer.from(prep.message, 'base64');
         const userSig = nacl.sign.detached(data, authority.secretKey);
 
-        const result = await this.post(
-            `staking/v1/stake/${
-                epKeys[0]
-            }/${authority.publicKey.toBase58()}/stake`,
-            {
-                message: prep.message,
-                userSignature: Buffer.from(userSig).toString('base64')
-            }
-        );
+        const result = await this.post(`staking/v1/claim`, {
+            message: prep.message,
+            userSignature: Buffer.from(userSig).toString('base64')
+        });
 
         const confirm = await this.get(
             `general/v1/confirm/${result.txSignature}?stakingExtract=true`


### PR DESCRIPTION
Trying to track down the MissingAuthoritySignature error. Thought it might have been caused by another error that is mistakenly decoded as MissingAuthoritySignature (error code 0). Added more unit tests to check if the decoding works. This doesn't seem to be the culprit.